### PR TITLE
React & Redux group project - Space Travelers' Hub, Missions page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "axios": "^1.3.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-redux": "^8.0.5",
@@ -5149,6 +5150,29 @@
       "integrity": "sha512-/BQzOX780JhsxDnPpH4ZiyrJAzcd8AfzFPkv+89veFSr1rcMjuq2JDCwypKaPeB6ljHp9KjXhPpjgCvQlWYuqg==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
+      "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -15138,6 +15162,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/psl": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^1.3.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.5",

--- a/src/index.js
+++ b/src/index.js
@@ -2,14 +2,18 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import { BrowserRouter as Router } from 'react-router-dom';
+import { Provider } from 'react-redux';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import store from './store/store';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
     <Router>
-      <App />
+      <Provider store={store}>
+        <App />
+      </Provider>
     </Router>
   </React.StrictMode>,
 );

--- a/src/pages/Mission/Mission.js
+++ b/src/pages/Mission/Mission.js
@@ -9,7 +9,7 @@ function Mission() {
 
   useEffect(() => {
     dispatch(fetchMissionData());
-  }, [dispatch]);
+  }, []);
 
   const handleMissionJoin = (mission) => {
     if (mission.joined) {

--- a/src/pages/Mission/Mission.js
+++ b/src/pages/Mission/Mission.js
@@ -8,7 +8,7 @@ function Mission() {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    dispatch(fetchMissionData());
+    if (!missions.length) dispatch(fetchMissionData());
   }, []);
 
   const handleMissionJoin = (mission) => {

--- a/src/pages/Mission/Mission.js
+++ b/src/pages/Mission/Mission.js
@@ -20,28 +20,38 @@ function Mission() {
   };
 
   return (
-    <>
-      {missions.map((miss) => (
-        <tr className={styles.table} key={miss.id}>
-          <td className={styles.name}>{miss.name}</td>
-          <td className={styles.desc}>{miss.description}</td>
-          <td>
-            <div className={miss.joined ? `${styles.memberBadge} ${styles.activeMission}` : styles.memberBadge}>
-              {miss.joined ? 'Active Member' : 'NOT A MEMBER'}
-            </div>
-          </td>
-          <td>
-            <button
-              className={miss.joined ? styles.leaveBtn : styles.joinBtn}
-              type="button"
-              onClick={() => handleMissionJoin(miss)}
-            >
-              {miss.joined ? 'Leave Mission' : 'Join Mission'}
-            </button>
-          </td>
+    <table className={styles.theTable}>
+      <thead className={styles.heading}>
+        <tr>
+          <th className={styles.eachMiss}>Mission</th>
+          <th className={styles.eachDesc}>Description</th>
+          <th className={styles.eachStat}>Status</th>
+          <th className={styles.eachAct}>Action</th>
         </tr>
-      ))}
-    </>
+      </thead>
+      <tbody>
+        {missions.map((miss) => (
+          <tr className={styles.table} key={miss.id}>
+            <td className={styles.name}>{miss.name}</td>
+            <td className={styles.desc}>{miss.description}</td>
+            <td>
+              <div className={miss.joined ? `${styles.memberBadge} ${styles.activeMission}` : styles.memberBadge}>
+                {miss.joined ? 'Active Member' : 'NOT A MEMBER'}
+              </div>
+            </td>
+            <td>
+              <button
+                className={miss.joined ? styles.leaveBtn : styles.joinBtn}
+                type="button"
+                onClick={() => handleMissionJoin(miss)}
+              >
+                {miss.joined ? 'Leave Mission' : 'Join Mission'}
+              </button>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
   );
 }
 

--- a/src/pages/Mission/Mission.js
+++ b/src/pages/Mission/Mission.js
@@ -1,7 +1,48 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { joinMission, leaveMission, fetchMissionData } from '../../store/mission/missionSlice';
+import styles from './Mission.module.css';
 
-const Mission = () => (
-  <div>Mission</div>
-);
+function Mission() {
+  const missions = useSelector((state) => state.mission.mission);
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(fetchMissionData());
+  }, [dispatch]);
+
+  const handleMissionJoin = (mission) => {
+    if (mission.joined) {
+      dispatch(leaveMission(mission.id));
+    } else {
+      dispatch(joinMission(mission.id));
+    }
+  };
+
+  return (
+    <>
+      {missions.map((miss) => (
+        <tr className={styles.table} key={miss.id}>
+          <td className={styles.name}>{miss.name}</td>
+          <td className={styles.desc}>{miss.description}</td>
+          <td>
+            <div className={miss.joined ? `${styles.memberBadge} ${styles.activeMission}` : styles.memberBadge}>
+              {miss.joined ? 'Active Member' : 'NOT A MEMBER'}
+            </div>
+          </td>
+          <td>
+            <button
+              className={miss.joined ? styles.leaveBtn : styles.joinBtn}
+              type="button"
+              onClick={() => handleMissionJoin(miss)}
+            >
+              {miss.joined ? 'Leave Mission' : 'Join Mission'}
+            </button>
+          </td>
+        </tr>
+      ))}
+    </>
+  );
+}
 
 export default Mission;

--- a/src/pages/Mission/Mission.module.css
+++ b/src/pages/Mission/Mission.module.css
@@ -1,0 +1,34 @@
+td {
+  table-layout: auto;
+  border: 1px solid;
+  width: auto;
+  padding: 10px;
+}
+
+.memberBadge {
+  text-align: center;
+  border: solid;
+  background-color: rgb(91, 91, 91);
+  color: #fff;
+  padding: 5px;
+  border-radius: 7px;
+}
+
+.activeMission {
+  background-color: rgb(22, 110, 157);
+}
+
+.joinBtn {
+  background: none;
+  border-radius: 7px;
+}
+
+.leaveBtn {
+  background: none;
+  color: rgb(255, 0, 0);
+  border-color: rgb(255, 0, 0);
+  border: solid;
+  border-radius: 5px;
+  padding: 10px;
+  margin-left: 40px;
+}

--- a/src/pages/Mission/Mission.module.css
+++ b/src/pages/Mission/Mission.module.css
@@ -1,4 +1,5 @@
-table, td {
+table,
+td {
   border: 1px solid;
   border-collapse: collapse;
 }

--- a/src/pages/Mission/Mission.module.css
+++ b/src/pages/Mission/Mission.module.css
@@ -1,26 +1,61 @@
-td {
-  table-layout: auto;
+table, td {
   border: 1px solid;
-  width: auto;
+  border-collapse: collapse;
+}
+
+th {
+  border: 1px solid;
+  border-collapse: collapse;
+  height: 40px;
+}
+
+.name {
+  width: 10%;
   padding: 10px;
+  height: 80px;
+}
+
+.eachStat {
+  width: 10%;
+}
+
+.eachAct {
+  width: 13%;
+}
+
+.table:nth-child(even) {
+  background-color: #ddd;
 }
 
 .memberBadge {
+  font-size: 13px;
   text-align: center;
   border: solid;
   background-color: rgb(91, 91, 91);
   color: #fff;
-  padding: 5px;
   border-radius: 7px;
+  margin-left: 15px;
+  margin-right: 15px;
+  padding: 3px;
+}
+
+.desc {
+  padding: 10px;
 }
 
 .activeMission {
-  background-color: rgb(22, 110, 157);
+  background-color: rgb(61, 157, 166);
+  font-size: 13px;
+  text-align: center;
+  border: none;
 }
 
 .joinBtn {
   background: none;
-  border-radius: 7px;
+  border: solid;
+  border-radius: 5px;
+  padding: 10px;
+  margin-left: 40px;
 }
 
 .leaveBtn {

--- a/src/store/mission/missionSlice.js
+++ b/src/store/mission/missionSlice.js
@@ -1,14 +1,67 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import axios from 'axios';
+
+export const fetchMissionData = createAsyncThunk(
+  'mission/fetchMissionData',
+  async () => {
+    const response = await axios.get('https://api.spacexdata.com/v3/missions');
+    const { data } = response;
+    return data.map((mission) => ({
+      id: mission.mission_id,
+      name: mission.mission_name,
+      description: mission.description,
+      joined: false,
+      link: mission.website,
+    }));
+  },
+);
 
 const initialState = {
   mission: [],
 };
 
 const missionSlice = createSlice({
-  name: 'rocket',
+  name: 'mission',
   initialState,
   reducers: {
+    joinMission: (state, action) => {
+      const { payload } = action;
+      return {
+        ...state,
+        mission: state.mission.map((mission) => {
+          if (mission.id === payload) {
+            return {
+              ...mission,
+              joined: true,
+            };
+          }
+          return mission;
+        }),
+      };
+    },
+    leaveMission: (state, action) => {
+      const { payload } = action;
+      return {
+        ...state,
+        mission: state.mission.map((mission) => {
+          if (mission.id === payload) {
+            return {
+              ...mission,
+              joined: false,
+            };
+          }
+          return mission;
+        }),
+      };
+    },
+  },
+  extraReducers: (builder) => {
+    builder.addCase(fetchMissionData.fulfilled, (state, action) => ({
+      ...state,
+      mission: action.payload,
+    }));
   },
 });
 
+export const { joinMission, leaveMission } = missionSlice.actions;
 export default missionSlice.reducer;

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -1,5 +1,4 @@
 import { configureStore } from '@reduxjs/toolkit';
-
 import rocketReducer from './rocket/rocketSlice';
 import missionReducer from './mission/missionSlice';
 


### PR DESCRIPTION
React & Redux group project - Space Travelers' Hub, missions according to microverse requirements which include:

Project requirements
Config & basic setup
Create React App.
Install [React Redux](https://react-redux.js.org/), [Redux Logger](https://www.npmjs.com/package/redux-logger) and [React Router](https://reactrouter.com/web/guides/quick-start).
Download the [free image](https://www.flaticon.com/free-icon/planet_3212567?term=space&page=1&position=19&page=1&position=19&related_id=3212567&origin=style) for the app logo.
Create routes and view components: rockets, missions, my profile. Add dragons [only if your team has 3 members]).
Use <NavLink /> for the page navigation links and style active class to indicate which section/page user is currently on (underline active navigation link).
Create directories for all Redux state slice files:rockets, missions, dragons [only if your team has 3 members].
Redux: Fetch data and update Redux store
Upon first render fetch data from the SpaceX API endpoints:
Missions: https://api.spacexdata.com/v3/missions


Missions:
mission_id
mission_name
description

flickr_images NOTE: Make sure you only dispatch those actions once and do not add data to store on every re-render (i.e. when changing views / using navigation). The missions data should only be fetched (once) when a user navigates to the Missions section.
Render UI:lists
Use useSelector() Redux Hook to select the state slices and render lists of rockets and missions in corresponding routes. i.e.:
// get rockets data from the store
const rockets = useSelector((state) => state.rockets)
You can style the whole application "by hand" or you could use [React Bootstrap](https://react-bootstrap.github.io/), a UI library that could speed up the process. This is a popular library and working with its components would be good practice.
Render a list of rockets (as per design). 
Redux: Write actions and reducers for booking rockets/dragons and joining missions



Create a reducer and action dispatcher for the "Join Mission" button. The logic here is practically the same as with rockets - you need to pass the mission's ID to the corresponding action and update the missions' state with the selected mission having a new key/value - reserved: true.
Redux: Write actions and reducers for canceling rockets/dragons and leaving missions
Here you need to follow the same logic as with the "Reserve rocket"/"Reserve dragon" and "Join mission" - but you need to set the reserved key to false.
Dispatch these actions upon click on the corresponding buttons.
Render UI: conditional components rendering


Missions that the user has joined already should show a badge "Active Member" instead of the default "NOT A MEMBER" and a button "Leave Mission" instead of the "Join Mission" button (as per design).
Rockets/Dragons and Missions should use the React conditional rendering syntax:
{rocket.reserved && (
    // render Cancel Rocket button
)}
Render UI: My Profile section
Compose two/three column layout and list ONLY the rockets/dragons reserved and missions joined by the user (as per design):
Render a list of all joined missions (use filter()).
